### PR TITLE
Prevent info-wrapper hidden behind the Rubyist's picture on IE9

### DIFF
--- a/views/screen.scss
+++ b/views/screen.scss
@@ -12,6 +12,7 @@ body {
 .tokei-box {
   position: relative;
   overflow: hidden;
+  z-index: 0;
 }
 
 .info-wrapper {


### PR DESCRIPTION
This pull request fixes the problem that the Rubyiest's picture hides the capition on IE9.
I made sure this problem happens only IE9.(There is no problem on IE7, IE8)

This commit might be a dirty hack but I hope this issue would help you.
