### PR TITLE
Add an missing underscore to Twitter account

### DIFF
--- a/data/hanachin.yaml
+++ b/data/hanachin.yaml
@@ -7,7 +7,7 @@ tokei:
 name:
   'Seiei Higa'
 title:
-  '@hanachin - Beach Coding'
+  '@hanachin_ - Beach Coding'
 bio:
   'RubyKaja Award 2012 Winner by Okinawa.rb'
 taken_by:


### PR DESCRIPTION
彼の Twitter アカウントは、@hanachin ではなく @hanachin_ でした orz
