### PR TITLE
Use bio, instead of description

### DIFF
--- a/data/emorima.yaml
+++ b/data/emorima.yaml
@@ -3,5 +3,5 @@ rubyists:
   - 'emorima'
 taken_at: "RubyKaigi 2023 After Party"
 taken_by: "pupupopo88"
-description: "Rails Girls JP, founder of emorihouse, and book author"
+bio: "Rails Girls JP, founder of emorihouse, and book author"
 source: "https://twitter.com/pupupopo88/status/1657360646659522561"

--- a/data/matz.yaml
+++ b/data/matz.yaml
@@ -3,5 +3,5 @@ rubyists:
   - 'Yukihiro "Matz" Matsumoto'
 taken_at: "Matsumoto Castle(RubyKaigi 2023 Day 0)"
 taken_by: "a_matsuda"
-description: "The Creator of Ruby"
+bio: "The Creator of Ruby"
 source: "https://twitter.com/a_matsuda/status/1657586595367895042"

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -8,7 +8,7 @@ export type Photo = {
   rubyists: string[] | undefined;
   taken_by: string | undefined;
   taken_at: string | undefined;
-  description: string | undefined;
+  bio: string | undefined;
 };
 
 export async function GET(request: Request) {

--- a/src/app/components/Caption.tsx
+++ b/src/app/components/Caption.tsx
@@ -27,8 +27,8 @@ export function Caption({ photo }: Props) {
   return (
     <>
       <div className="text-2xl sm:text-3xl md:text-4xl">{personComponents}</div>
-      {photo.description && (
-        <div className="text-md sm:text-lg md:text-xl">{photo.description}</div>
+      {photo.bio && (
+        <div className="text-md sm:text-lg md:text-xl">{photo.bio}</div>
       )}
       <div className="text-md sm:text-xl">
         {photo.taken_by && (


### PR DESCRIPTION
description(説明)だと、時計の背景写真の説明なのか、Rubyistの説明なのか悩みました。 「(背景画像が)Rubyistの」時計、なのがrubyistokeiだと認識しています。

どのような写真であるかは"taken_at"である程度補足できると思います(cf. matz)。
よって、descriptionが人物であることが明快になるように、bioにしたい。