### PR TITLE
Update the image URL to Gyazo instead of Discord's CDN

### DIFF
--- a/data/team-itamae.yaml
+++ b/data/team-itamae.yaml
@@ -1,4 +1,4 @@
-image: "https://cdn.discordapp.com/attachments/613976069745278997/1123894137041731614/DSC02344.JPG"
+image: "https://i.gyazo.com/03b1ed6ad4739c017b7d5240c043fed2.jpg"
 rubyists:
   - 'unasuke'
   - 'sue445'

--- a/data/urban-unasuke.yaml
+++ b/data/urban-unasuke.yaml
@@ -1,4 +1,4 @@
-image: "https://cdn.discordapp.com/attachments/613976069745278997/1109335302515982376/DSC_6415.JPG"
+image: "https://i.gyazo.com/85043b74bbc110a8e9102b9f5f79afea.jpg"
 rubyists:
   - 'unasuke'
 taken_at: "Odaiba(Daiba) 2019/11/30"


### PR DESCRIPTION
Resolve: https://github.com/rubyistokei/rubyistokei.github.io/issues/166

件のニュースを見てたしかに～となったので画像をGyazoにアップロードしなおしてURLを更新しました！